### PR TITLE
Add dbus

### DIFF
--- a/ubuntu-16.04/http/xenial_minimal_vagrant.preseed
+++ b/ubuntu-16.04/http/xenial_minimal_vagrant.preseed
@@ -88,7 +88,7 @@ tasksel tasksel/first multiselect
 d-i hw-detect/load_firmware boolean false
 d-i mirror/http/proxy string
 d-i pkgsel/update-policy select none
-d-i pkgsel/include string openssh-server bash-completion
+d-i pkgsel/include string openssh-server bash-completion dbus
 d-i pkgsel/upgrade select full-upgrade
 
 # Final Setup


### PR DESCRIPTION
Small change to make Vagrant 1.8.5 work; the plugins/guests/debian/cap/change_host_name.rb  script was change recently and needs dbus to work.

Tested locally with packer; and adding dbus fixes issue: https://github.com/nrclark/libvirt-packer-scripts/issues/1
